### PR TITLE
Enable daily dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
With this PR, [Dependabot](https://dependabot.com/) can automatically scan the dependencies daily as described in `requirements.txt` and create a PR if there is a newer version of the upstream package available.

**Note:**
At the moment it is only `caikit` dependency but this will probably grow.