### PR TITLE
Bump caikit to 0.11.0

### DIFF
--- a/.github/workflows/build-library.yml
+++ b/.github/workflows/build-library.yml
@@ -26,11 +26,14 @@ jobs:
     strategy:
       matrix:
         python-version:
+          - setup: "3.8"
+            tox: "py38"
           - setup: "3.9"
             tox: "py39"
           - setup: "3.10"
             tox: "py310"
-
+          - setup: "3.11"
+            tox: "py311"
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version.setup }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers=[
     "License :: OSI Approved :: Apache Software License"
 ]
 dependencies = [
-    "caikit==0.8.0"
+    "caikit==0.11.0"
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ version = "0.0.1"
 description = "Caikit Computer Vision"
 license = {text = "Apache-2.0"}
 readme = "README.md"
-requires-python = "~=3.9"
+requires-python = "~=3.8"
 classifiers=[
     "License :: OSI Approved :: Apache Software License"
 ]


### PR DESCRIPTION
- Bumps caikit to `0.11.0` to add image defs
- Adds support for other versions of Python supports by caikit