### PR TITLE
Update python support and caikit version

### DIFF
--- a/.github/workflows/build-library.yml
+++ b/.github/workflows/build-library.yml
@@ -26,10 +26,14 @@ jobs:
     strategy:
       matrix:
         python-version:
+          - setup: "3.8"
+            tox: "py38"
           - setup: "3.9"
             tox: "py39"
           - setup: "3.10"
             tox: "py310"
+          - setup: "3.11"
+            tox: "py311"
 
     steps:
       - uses: actions/checkout@v3

--- a/caikit_computer_vision/data_model/image_classification.py
+++ b/caikit_computer_vision/data_model/image_classification.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Data structures for classification in images."""
 
+# Standard
 from typing import List
 
 # Third Party

--- a/caikit_computer_vision/data_model/image_classification.py
+++ b/caikit_computer_vision/data_model/image_classification.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 """Data structures for classification in images."""
 
+from typing import List
+
 # Third Party
 from py_to_proto.dataclass_to_proto import Annotated, FieldNumber
 
@@ -32,5 +34,5 @@ class ImageClassification(DataObjectBase):
 
 @dataobject(package="caikit_data_model.caikit_computer_vision")
 class ImageClassificationResult(DataObjectBase):
-    classifications: Annotated[list[ImageClassification], FieldNumber(1)]
+    classifications: Annotated[List[ImageClassification], FieldNumber(1)]
     producer_id: Annotated[ProducerId, FieldNumber(2)]

--- a/caikit_computer_vision/data_model/object_detection.py
+++ b/caikit_computer_vision/data_model/object_detection.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 """Data structures for text object detection in images."""
 
+from typing import List
+
 # Third Party
 from py_to_proto.dataclass_to_proto import Annotated, FieldNumber
 
@@ -41,5 +43,5 @@ class DetectedObject(DataObjectBase):
 
 @dataobject(package="caikit_data_model.caikit_computer_vision")
 class ObjectDetectionResult(DataObjectBase):
-    detected_objects: Annotated[list[BoundingBox], FieldNumber(1)]
+    detected_objects: Annotated[List[BoundingBox], FieldNumber(1)]
     producer_id: Annotated[ProducerId, FieldNumber(2)]

--- a/caikit_computer_vision/data_model/object_detection.py
+++ b/caikit_computer_vision/data_model/object_detection.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Data structures for text object detection in images."""
 
+# Standard
 from typing import List
 
 # Third Party

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,12 +9,12 @@ version = "0.0.1"
 description = "Caikit Computer Vision"
 license = {text = "Apache-2.0"}
 readme = "README.md"
-requires-python = "~=3.9"
+requires-python = "~=3.8"
 classifiers=[
     "License :: OSI Approved :: Apache Software License"
 ]
 dependencies = [
-    "caikit==0.8.0"
+    "caikit[runtime-grpc,runtime-http]>=0.16.0,<0.17.0",
 ]
 
 [project.urls]

--- a/tests/data_model/test_tasks.py
+++ b/tests/data_model/test_tasks.py
@@ -70,10 +70,12 @@ def test_tasks(
     reset_module_registry, reset_module_backend_registry, task: Type[TaskBase]
 ):
     """Common tests for all tasks"""
-    # Only support single required param named "inputs"
-    assert set(task.get_required_parameters().keys()) == {"inputs"}
-    input_type = task.get_required_parameters()["inputs"]
-    output_type = task.get_output_type()
+    # Only support single required param named "inputs", current flavor is
+    # no streaming for any vision task types (at least not yet!)
+    assert set(task.get_required_parameters(input_streaming=False).keys()) == {"inputs"}
+
+    input_type = task.get_required_parameters(input_streaming=False)["inputs"]
+    output_type = task.get_output_type(output_streaming=False)
 
     # Version with the right signature and nothing else
     @module(id="foo1", name="Foo", version="0.0.0", task=task)


### PR DESCRIPTION
- Adds support for python 3.8 & 3.11
- Updates caikit to `0.16.X`
- Fixes type annotations for older versions of python (< 3.9)