### PR TITLE
Segmentation defs

### DIFF
--- a/caikit_computer_vision/data_model/__init__.py
+++ b/caikit_computer_vision/data_model/__init__.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 # Local
-from . import image_classification, object_detection, tasks
+from . import image_classification, image_segmentation, object_detection, tasks
 from .image_classification import *
+from .image_segmentation import *
 from .object_detection import *

--- a/caikit_computer_vision/data_model/image_segmentation.py
+++ b/caikit_computer_vision/data_model/image_segmentation.py
@@ -22,11 +22,12 @@ from py_to_proto.dataclass_to_proto import Annotated, FieldNumber
 
 # First Party
 from caikit.core import DataObjectBase, dataobject
-from caikit.interfaces.vision import data_model as caikit_dm
 from caikit.interfaces.common.data_model import ProducerId
+from caikit.interfaces.vision import data_model as caikit_dm
 import alog
 
 log = alog.use_channel("DATAM")
+
 
 @dataobject(package="caikit_data_model.caikit_computer_vision")
 class ObjectSegment(DataObjectBase):
@@ -37,6 +38,7 @@ class ObjectSegment(DataObjectBase):
     # as a binary image, where 0 is background, and 255 is part of the
     # object to align with HF task definitions.
     mask: Annotated[caikit_dm.Image, FieldNumber(3)]
+
 
 @dataobject(package="caikit_data_model.caikit_computer_vision")
 class ImageSegmentationResult(DataObjectBase):

--- a/caikit_computer_vision/data_model/image_segmentation.py
+++ b/caikit_computer_vision/data_model/image_segmentation.py
@@ -1,0 +1,44 @@
+# Copyright The Caikit Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Data structures for segmentation in images."""
+
+
+# Standard
+from typing import List
+
+# Third Party
+from py_to_proto.dataclass_to_proto import Annotated, FieldNumber
+
+# First Party
+from caikit.core import DataObjectBase, dataobject
+from caikit.interfaces.vision import data_model as caikit_dm
+from caikit.interfaces.common.data_model import ProducerId
+import alog
+
+log = alog.use_channel("DATAM")
+
+@dataobject(package="caikit_data_model.caikit_computer_vision")
+class ObjectSegment(DataObjectBase):
+    score: Annotated[float, FieldNumber(1)]
+    label: Annotated[str, FieldNumber(2)]
+    # TODO: We should be able to specify subtype, i.e., PIL image mode.
+    # This mask should be image mode (L), 8 bit grayscale image treated
+    # as a binary image, where 0 is background, and 255 is part of the
+    # object to align with HF task definitions.
+    mask: Annotated[caikit_dm.Image, FieldNumber(3)]
+
+@dataobject(package="caikit_data_model.caikit_computer_vision")
+class ImageSegmentationResult(DataObjectBase):
+    object_segments: Annotated[List[ObjectSegment], FieldNumber(1)]
+    producer_id: Annotated[ProducerId, FieldNumber(2)]

--- a/caikit_computer_vision/data_model/tasks.py
+++ b/caikit_computer_vision/data_model/tasks.py
@@ -23,6 +23,7 @@ from caikit.core import TaskBase, task
 
 # Local
 from .image_classification import ImageClassificationResult
+from .image_segmentation import ImageSegmentationResult
 from .object_detection import ObjectDetectionResult
 
 
@@ -46,4 +47,16 @@ class ImageClassificationTask(TaskBase):
     """The image classification task is responsible for taking an input image
     and producing an iterable of objects containing class names and typically
     confidence scores.
+    """
+
+
+@task(
+    required_parameters={"inputs": bytes},
+    output_type=ImageSegmentationResult,
+)
+class ImageSegmentationTask(TaskBase):
+    """The image classification task is responsible for taking an input image
+    and producing a pixel mask with optional class names and confidence scores.
+    Note that at the moment, this task encapsulates all segmentation types,
+    I.e., instance, object, semantic, etc...
     """

--- a/tests/data_model/test_tasks.py
+++ b/tests/data_model/test_tasks.py
@@ -64,6 +64,7 @@ class InvalidType:
     (
         tasks.ObjectDetectionTask,
         tasks.ImageClassificationTask,
+        tasks.ImageSegmentationTask,
     ),
 )
 def test_tasks(


### PR DESCRIPTION
Adds preliminary definitions for image segmentation; these essentially mirror the HF task defs, where a segmentation is an iterable of segments, each of which has a score, name, and mask.

In some situations, it might be nice to optionally bundle segmentation + detection information; this will be done in a follow-up PR.
