### PR TITLE
Pin caikit

### DIFF
--- a/examples/runtime/run_train_and_inference.py
+++ b/examples/runtime/run_train_and_inference.py
@@ -84,7 +84,7 @@ if __name__ == "__main__":
         im_bytes = f.read()
     request = objectdetectiontaskrequest_pb2.ObjectDetectionTaskRequest(
         inputs=im_bytes,
-        threshold=0.5,
+        threshold=0.0,
     )
     inference_stub = computervisionservice_pb2_grpc.ComputerVisionServiceStub(
         channel=channel

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,8 @@ classifiers=[
     "License :: OSI Approved :: Apache Software License"
 ]
 dependencies = [
-    "caikit[runtime-grpc,runtime-http,interfaces-vision]>=0.16.0,<0.27.0",
+    "caikit[runtime-grpc,runtime-http,interfaces-vision]==0.16.0",
+    "py-to-proto==0.4.1",
     "transformers>=4.27.1,<5",
     "torch>2.0,<3",
     "timm>=0.9.5,<1"


### PR DESCRIPTION
Pinning to caikit 0.16 (super temporarily) - the structure of the generated protos that are dumped by runtime through the demo has changed in the more recent versions, and the demo is written using the old version.

Aiming to update this by EOD.