### PR TITLE
Inference on Newly Trained Model in Runtime Demo

### DIFF
--- a/examples/runtime/README.md
+++ b/examples/runtime/README.md
@@ -34,9 +34,9 @@ python3 run_train_and_inference.py
 
 This will create a gRPC client to call `.train()` on the object detector module, which currently a stub. Note that the training parameters are not actually being used here and only are present for illustration purposes to show how args are passed. The result of the train job is simply the same model provided as the base, exported under a new model ID, `new_model`.
 
-Then, an inference request is sent to the _original_ model, which calls `.run()`, to produce the prediction that is logged by the script.
+Then, an inference request is sent to the newly loaded model, which calls `.run()`, to produce the prediction that is logged by the script.
 
-NOTE: it would be a good idea to show how to load and run the new model in this demo, but since loading is generally handled by kserve/model mesh, for now we just hit the old one.
+NOTE: in order to hit the new model, we need to set `runtime.lazy_load_local_models=True` in the runtime config, which by default will sync the local model dir with the in memory runtime (i.e., load models that have been added and unload models that have been deleted) every 10 seconds. If inference fails, try setting the log level to `debug2` and ensure that you see the runtime polling for new models periodically.
 
 ## A Deeper Look
 

--- a/examples/runtime/common.py
+++ b/examples/runtime/common.py
@@ -42,5 +42,7 @@ PROTO_EXPORT_DIR = "protos"
 
 # Example model ID to use when creating a small model at model dir init time
 DEMO_MODEL_ID = "my_model"
+# New model that we are going to train and run an inference call on
+NEW_MODEL_ID = "new_model"
 
 RUNTIME_PORT = 8085

--- a/runtime_config.yaml
+++ b/runtime_config.yaml
@@ -6,7 +6,7 @@ jvm_options: []
 runtime:
   library: caikit_computer_vision
   local_models_dir: models
-  lazy_load_local_models": True
+  lazy_load_local_models: True
   grpc:
     enabled: True
   http:
@@ -21,6 +21,8 @@ runtime:
 
 log:
   formatter: pretty # optional: log formatter is set to json by default
+  # By default log level is info - you can override it as shown below.
+  # level: debug2
 
 model_management:
   finders:


### PR DESCRIPTION
There's an oopsie in the sample runtime config that's messing up lazy model loading - this fixes the typo and updates the demo to lazily load and call the new model.